### PR TITLE
Initial changes required to run the Shoreline plug-ins on viz003

### DIFF
--- a/ClientServerManagers/shClient.cpp
+++ b/ClientServerManagers/shClient.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <chrono>
 
 int main() {
   Shoreline::VectorMesh<long> vm;

--- a/ClientServerManagers/src/MeshCourier.cpp
+++ b/ClientServerManagers/src/MeshCourier.cpp
@@ -1,5 +1,6 @@
 #include "MeshCourier.h"
 #include <iostream>
+#include <chrono>
 
 // vtk includes
 #ifdef BUILD_WITH_VTK

--- a/ClientServerManagers/src/MeshCourierClient.cpp
+++ b/ClientServerManagers/src/MeshCourierClient.cpp
@@ -1,4 +1,5 @@
 #include "MeshCourierClient.h"
+#include <chrono>
 
 namespace Shoreline {
 bool MeshClient::attach(const int port) {

--- a/ParaViewPlugins/createHarmonicSkeleton/CMakeLists.txt
+++ b/ParaViewPlugins/createHarmonicSkeleton/CMakeLists.txt
@@ -10,10 +10,12 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_FLAGS "-Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+set(CACHE_PATH_OPTION "" CACHE STRING "path to the GUI cache")
 
 find_package(ParaView REQUIRED)
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+add_compile_definitions(CACHE_PATH="${CACHE_PATH_OPTION}")
 # enable_testing()
 
 # Required for python testing

--- a/ParaViewPlugins/createHarmonicSkeleton/Plugin/createSkeletonFilters/CMakeLists.txt
+++ b/ParaViewPlugins/createHarmonicSkeleton/Plugin/createSkeletonFilters/CMakeLists.txt
@@ -6,17 +6,15 @@ vtk_module_add_module(createSkeletonFilters
   # FORCE_STATIC # Using FORCE_STATIC build the vtk module statically into the plugin library, to avoid confusion when loading
   CLASSES ${classes})
 
-#Find CGAL
+#Find external package
 find_package(LIBIGL REQUIRED)
 find_package(CGAL REQUIRED)
 find_package(Boost REQUIRED) 
-# find_package (Eigen3 3.3 REQUIRED NO_MODULE)
-# add_definitions("-DCGAL_EIGEN3_ENABLED")#-DCGAL_HEADER_ONLY ***Commented this out***
 
 vtk_module_include( createSkeletonFilters
   PRIVATE "/users/jeffhadley/Builds/src/libigl/include"
 )
 vtk_module_link( createSkeletonFilters PRIVATE CGAL::CGAL Eigen3::Eigen igl::core Boost::boost)
-	#PRIVATE CGAL::CGAL Eigen3::Eigen igl::core ${Boost_LIBRARIES})
+
 paraview_add_server_manager_xmls(
 XMLS  createSkeletonFilter.xml)

--- a/ParaViewPlugins/createHarmonicSkeleton/Plugin/createSkeletonFilters/CMakeLists.txt
+++ b/ParaViewPlugins/createHarmonicSkeleton/Plugin/createSkeletonFilters/CMakeLists.txt
@@ -9,15 +9,14 @@ vtk_module_add_module(createSkeletonFilters
 #Find CGAL
 find_package(LIBIGL REQUIRED)
 find_package(CGAL REQUIRED)
+find_package(Boost REQUIRED) 
 # find_package (Eigen3 3.3 REQUIRED NO_MODULE)
-add_definitions("-DCGAL_EIGEN3_ENABLED")#-DCGAL_HEADER_ONLY
+# add_definitions("-DCGAL_EIGEN3_ENABLED")#-DCGAL_HEADER_ONLY ***Commented this out***
 
 vtk_module_include( createSkeletonFilters
-  PRIVATE "/Users/coreylee/Git/libigl/include"
+  PRIVATE "/users/jeffhadley/Builds/src/libigl/include"
 )
-vtk_module_link( createSkeletonFilters
-  PRIVATE CGAL::CGAL Eigen3::Eigen igl::core ${Boost_LIBRARIES}
-)
-
+vtk_module_link( createSkeletonFilters PRIVATE CGAL::CGAL Eigen3::Eigen igl::core Boost::boost)
+	#PRIVATE CGAL::CGAL Eigen3::Eigen igl::core ${Boost_LIBRARIES})
 paraview_add_server_manager_xmls(
 XMLS  createSkeletonFilter.xml)

--- a/ParaViewPlugins/createHarmonicSkeleton/Plugin/createSkeletonFilters/vtkcreateSkeletonFilter.cxx
+++ b/ParaViewPlugins/createHarmonicSkeleton/Plugin/createSkeletonFilters/vtkcreateSkeletonFilter.cxx
@@ -203,7 +203,8 @@ int vtkcreateSkeletonFilter::RequestData(
   // write skeleton to file
   vtkSmartPointer<vtkXMLPolyDataWriter> writer =
     vtkSmartPointer<vtkXMLPolyDataWriter>::New();
-  writer->SetFileName ("/Users/coreylee/Git/cache/skeleton.vtp");
+  std::string cache_path = std::string(CACHE_PATH) + std::string( "/skeleton.vtp");
+  writer->SetFileName ( cache_path.c_str() );
   writer->SetInputData ( skelOut );
   writer->Write();
   

--- a/ParaViewPlugins/interactiveSkeleton/CMakeLists.txt
+++ b/ParaViewPlugins/interactiveSkeleton/CMakeLists.txt
@@ -24,12 +24,15 @@ include(GNUInstallDirs)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+set(CACHE_PATH_OPTION "" CACHE STRING "path to the GUI cache")
 
 set("_paraview_plugin_default_${CMAKE_PROJECT_NAME}" ON)
 paraview_plugin_scan(
   PLUGIN_FILES      "${CMAKE_CURRENT_SOURCE_DIR}/Plugin/paraview.plugin"
   PROVIDES_PLUGINS  plugins
   REQUIRES_MODULES  required_modules)
+
+add_compile_definitions(CACHE_PATH="${CACHE_PATH_OPTION}")
 
 foreach (module IN LISTS required_modules)
   if (NOT TARGET "${module}")

--- a/ParaViewPlugins/interactiveSkeleton/Plugin/Filters/CMakeLists.txt
+++ b/ParaViewPlugins/interactiveSkeleton/Plugin/Filters/CMakeLists.txt
@@ -9,16 +9,11 @@ vtk_module_add_module(interactiveSkeletonFilters
   CLASSES ${classes})
 
 #Find external libraries
-# find_package(CGAL REQUIRED)
-
 find_package(LIBIGL REQUIRED igl::core igl::common)
-# find_package(Embree 3.12.1 REQUIRED)
 find_package (Eigen3 3.3 REQUIRED NO_MODULE)
-# add_definitions("-DCGAL_EIGEN3_ENABLED") # -DCGAL_HEADER_ONLY
 
 vtk_module_link(interactiveSkeletonFilters
   PUBLIC igl::core igl::common Eigen3::Eigen ${EMBREE_LIBRARIES}
 )
-# vtk_module_include(interactiveSkeletonFilters PUBLIC ${EMBREE_INCLUDES} "/Users/coreylee/Git/libigl_Test/libigl/external/embree/include" "/Users/coreylee/Git/libigl_Test/build/include")
-vtk_module_include(interactiveSkeletonFilters PUBLIC ${EMBREE_INCLUDES} "/users/jeffhadley/Builds/src/libigl/include/igl/embree" "/users/jeffhadley/Builds/src/libigl/include") 
+
 paraview_add_server_manager_xmls(XMLS vtkInteractiveSkeletonFilter.xml)

--- a/ParaViewPlugins/interactiveSkeleton/Plugin/Filters/CMakeLists.txt
+++ b/ParaViewPlugins/interactiveSkeleton/Plugin/Filters/CMakeLists.txt
@@ -19,6 +19,6 @@ find_package (Eigen3 3.3 REQUIRED NO_MODULE)
 vtk_module_link(interactiveSkeletonFilters
   PUBLIC igl::core igl::common Eigen3::Eigen ${EMBREE_LIBRARIES}
 )
-vtk_module_include(interactiveSkeletonFilters PUBLIC ${EMBREE_INCLUDES} "/Users/coreylee/Git/libigl_Test/libigl/external/embree/include" "/Users/coreylee/Git/libigl_Test/build/include")
-
+# vtk_module_include(interactiveSkeletonFilters PUBLIC ${EMBREE_INCLUDES} "/Users/coreylee/Git/libigl_Test/libigl/external/embree/include" "/Users/coreylee/Git/libigl_Test/build/include")
+vtk_module_include(interactiveSkeletonFilters PUBLIC ${EMBREE_INCLUDES} "/users/jeffhadley/Builds/src/libigl/include/igl/embree" "/users/jeffhadley/Builds/src/libigl/include") 
 paraview_add_server_manager_xmls(XMLS vtkInteractiveSkeletonFilter.xml)

--- a/ParaViewPlugins/interactiveSkeleton/Plugin/Filters/vtkInteractiveSkeletonFilter.cxx
+++ b/ParaViewPlugins/interactiveSkeleton/Plugin/Filters/vtkInteractiveSkeletonFilter.cxx
@@ -82,7 +82,8 @@ int vtkInteractiveSkeletonFilter::RequestData(
   //////////////////////////////////////////////////////////////////////////////
   // Read the representation of the widget from file
   vtkXMLPolyDataReader* reader = vtkXMLPolyDataReader::New();
-  reader->SetFileName ("/Users/coreylee/Git/cache/skeletonMod.vtp");
+  std::string cache_path = std::string(CACHE_PATH) + std::string( "/skeletonMod.vtp" );
+  reader->SetFileName ( cache_path.c_str() );
   reader->Update();
 
   vtkPolyData* sklWidget = reader->GetOutput();

--- a/ParaViewPlugins/interactiveSkeleton/Plugin/Filters/vtkMySkeletonRepresentation.cxx
+++ b/ParaViewPlugins/interactiveSkeleton/Plugin/Filters/vtkMySkeletonRepresentation.cxx
@@ -58,7 +58,8 @@ vtkMySkeletonRepresentation::vtkMySkeletonRepresentation()
   //////////////////////////////////////////////////////////////////////////////
   // Read the representation of the widget from file
   vtkNew<vtkXMLPolyDataReader> reader;
-  reader->SetFileName("/Users/coreylee/Git/cache/skeleton.vtp");
+  std::string cache_path_skel = std::string(CACHE_PATH) + std::string("/skeleton.vtp");
+  reader->SetFileName( cache_path_skel.c_str() );
   reader->Update();
 
   this->Skeleton = vtkMySkeletonSource::New();
@@ -67,7 +68,8 @@ vtkMySkeletonRepresentation::vtkMySkeletonRepresentation()
   this->Skeleton->Update();
 
   vtkNew<vtkXMLPolyDataWriter> writer;
-  writer->SetFileName ("/Users/coreylee/Git/cache/skeletonMod.vtp");
+  std::string cache_path_skelMod = std::string(CACHE_PATH) + std::string("/skeletonMod.vtp");
+  writer->SetFileName ( cache_path_skelMod.c_str() );
   writer->SetInputData ( this->Skeleton->GetSkeleton() );
   writer->Write();
 
@@ -1056,7 +1058,8 @@ void vtkMySkeletonRepresentation::WidgetInteraction(double e[2])
   this->BuildRepresentation();
 
   vtkXMLPolyDataWriter* writer = vtkXMLPolyDataWriter::New();
-  writer->SetFileName ("/Users/coreylee/Git/cache/skeletonMod.vtp");
+  std::string cache_path_skelMod2 = std::string(CACHE_PATH) + std::string("/skeletonMod.vtp");
+  writer->SetFileName ( cache_path_skelMod2.c_str() );
   writer->SetInputData ( this->Skeleton->GetSkeleton() );
   writer->Write();
   writer->Delete();

--- a/ParaViewPlugins/scaleDirection/Plugin/Filters/CMakeLists.txt
+++ b/ParaViewPlugins/scaleDirection/Plugin/Filters/CMakeLists.txt
@@ -6,7 +6,7 @@ vtk_module_add_module(scaleDirectionFilters
 
 find_package(LIBIGL REQUIRED COMPONENTS core)
 find_package (Eigen3 3.3 REQUIRED)
-vtk_module_include(scaleDirectionFilters PRIVATE "/Users/coreylee/Git/libigl/include/")
+vtk_module_include(scaleDirectionFilters PRIVATE "/users/jeffhadley/Builds/src/libigl/include/")
 vtk_module_link(   scaleDirectionFilters PRIVATE Eigen3::Eigen igl::core)
 
 paraview_add_server_manager_xmls(XMLS  scaleDirectionFilter.xml)

--- a/ParaViewPlugins/scaleNormal/Plugin/Filters/CMakeLists.txt
+++ b/ParaViewPlugins/scaleNormal/Plugin/Filters/CMakeLists.txt
@@ -6,7 +6,7 @@ vtk_module_add_module(scaleNormalFilters
 
 find_package(LIBIGL REQUIRED COMPONENTS core)
 find_package (Eigen3 3.3 REQUIRED)
-vtk_module_include(scaleNormalFilters PRIVATE "/Users/coreylee/Git/libigl/include/")
+vtk_module_include(scaleNormalFilters PRIVATE "/users/jeffhadley/Builds/src/libigl/include/")
 vtk_module_link(   scaleNormalFilters PRIVATE Eigen3::Eigen igl::core)
 
 paraview_add_server_manager_xmls(XMLS  scaleNormalFilter.xml)

--- a/ParaViewPlugins/translateFeature/Plugin/Filters/CMakeLists.txt
+++ b/ParaViewPlugins/translateFeature/Plugin/Filters/CMakeLists.txt
@@ -6,7 +6,7 @@ vtk_module_add_module(translateFeatureFilters
 
 find_package(LIBIGL REQUIRED COMPONENTS core)
 find_package (Eigen3 3.3 REQUIRED)
-vtk_module_include(translateFeatureFilters PRIVATE "/Users/coreylee/Git/libigl/include/")
+vtk_module_include(translateFeatureFilters PRIVATE "/users/jeffhadley/Builds/src/libigl/include/")
 vtk_module_link(   translateFeatureFilters PRIVATE Eigen3::Eigen igl::core)
 
 paraview_add_server_manager_xmls(XMLS  translateFeatureFilter.xml)


### PR DESCRIPTION
Changed lib IGL paths, added CMake compiler options and fields. Made changes to find the correct BoostConfig.cmake file for the createHarmonicSkeleton plugin.  Changes were necessary to run the plug-ins on CU Boulder's PHASTA group viz-nodes.