### PR TITLE
Modified softSetup.sh to include export commands

### DIFF
--- a/ClientServerManagers/softSetup.sh
+++ b/ClientServerManagers/softSetup.sh
@@ -2,3 +2,5 @@ soft add +cmake-3.16.0
 soft add +gcc-9.2.0
 soft add +mkl-2018u3
 soft add +openmpi-gnu-2.1.0-gnu49-thread
+export PETSC_DIR=/users/nelson15/LIBS/petsc/
+export PETSC_ARCH=arch-linux2-c-debug


### PR DESCRIPTION
Export commands of PETSC_DIR and PETSC_ARCH are for cmake to find PETSC. Passing -DPETSC_DIR=path/to/petsc/build/ into cmake does not work.  
	modified:   softSetup.sh